### PR TITLE
Add link to app rating

### DIFF
--- a/src/containers/DefaultContainer.vue
+++ b/src/containers/DefaultContainer.vue
@@ -42,6 +42,9 @@
         <a href="https://github.com/AnthonyRonning/ShineWallet">
           <i class="fa fa-github"></i>
         </a>
+        <a href="https://app-center.openintents.org/appco/1465/comment">
+          <i class="fa fa-star"></i>
+        </a>
       </div>
 
       <div class="ml-auto">


### PR DESCRIPTION
This PR adds a link to the blockstack app rating platform OI App Center (free, open source and respectful).

The link for ShineWallet is:
https://app-center.openintents.org/appco/1465/comment

Please let me know if that makes sense for you. Let's build a good ecosystem!